### PR TITLE
Add support for Lambda API integration

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   build_frontend:
-    name: Build front-end components
+    name: Build and deploy front-end components
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -28,3 +28,29 @@ jobs:
           aws-region: eu-west-1
       - name: Upload to S3
         run: aws s3 sync ui/build s3://turbofelo --delete
+  build_backend:
+    name: Build and deploy backend Lambda functions
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: registerUser install
+        run: |
+          cd db/registerUser
+          npm install
+      - name: retrieveAllStats install
+        run: |
+          cd db/retrieveAllStats
+          npm install
+      - name: retrieveGames install
+        run: |
+          cd db/retrieveGames
+          npm install
+      - name: retrieveUsers install
+        run: |
+          cd db/retrieveUsers
+          npm install
+      - name: updateElo install
+        run: |
+          cd db/updateElo
+          npm install
+          npm run compile

--- a/db/registerUser/index.js
+++ b/db/registerUser/index.js
@@ -2,7 +2,7 @@
 const MongoClient = require("mongodb").MongoClient;
  
 // Replace the following with your Atlas connection string                                                                                                                                        
-const MONGODB_URI = "secret";
+const MONGODB_URI = "%MONGO_SECRET%";
 
 let cachedClient = null;
 let cachedDb = null;
@@ -64,6 +64,10 @@ exports.handler = async (event, context) => {
   const response = {
       statusCode: 200,
       body: JSON.stringify(users),
+      headers: {
+          'Content-Type': 'application/json',
+          'Access-Control-Allow-Origin': '*'
+      }
   };
 
   await closeConnection();

--- a/db/retrieveAllStats/index.js
+++ b/db/retrieveAllStats/index.js
@@ -2,7 +2,7 @@
 const MongoClient = require("mongodb").MongoClient;
 
 // Replace the following with your Atlas connection string
-const MONGODB_URI = "secret";
+const MONGODB_URI = "%MONGO_SECRET%";
 
 let cachedClient = null;
 let cachedDb = null;
@@ -136,6 +136,10 @@ exports.handler = async (event, context) => {
     const response = {
         statusCode: 200,
         body: JSON.stringify(statDictionary),
+        headers: {
+            'Content-Type': 'application/json',
+            'Access-Control-Allow-Origin': '*'
+        }
     };
 
     await closeConnection();

--- a/db/retrieveGames/index.js
+++ b/db/retrieveGames/index.js
@@ -3,7 +3,7 @@ const MongoClient = require("mongodb").MongoClient;
 const ObjectId = require("mongodb").ObjectId;
 
 // Replace the following with your Atlas connection string
-const MONGODB_URI = "secret";
+const MONGODB_URI = "%MONGO_SECRET%";
 
 let cachedClient = null;
 let cachedDb = null;
@@ -72,6 +72,10 @@ exports.handler = async (event, context) => {
         const response = {
             statusCode: 404,
             body: JSON.stringify("User not found"),
+            headers: {
+                'Content-Type': 'application/json',
+                'Access-Control-Allow-Origin': '*'
+            }
         };
 
         await closeConnection();
@@ -102,6 +106,10 @@ exports.handler = async (event, context) => {
     const response = {
         statusCode: 200,
         body: JSON.stringify(games),
+        headers: {
+            'Content-Type': 'application/json',
+            'Access-Control-Allow-Origin': '*'
+        }
     };
 
     await closeConnection();

--- a/db/retrieveUsers/index.js
+++ b/db/retrieveUsers/index.js
@@ -2,7 +2,7 @@
 const MongoClient = require("mongodb").MongoClient;
 
 // Replace the following with your Atlas connection string
-const MONGODB_URI = "secret";
+const MONGODB_URI = "%MONGO_SECRET%";
 
 let cachedClient = null;
 let cachedDb = null;
@@ -47,6 +47,7 @@ async function closeConnection() {
 
 exports.handler = async (event, context) => {
     const isTest = event.queryStringParameters?.test === "true";
+    console.log(event, context);
 
     /* By default, the callback waits until the runtime event loop is empty before freezing the process and returning the results to the caller. Setting this property to false requests that AWS Lambda freeze the process soon after the callback is invoked, even if there are events in the event loop. AWS Lambda will freeze the process, any state data, and the events in the event loop. Any remaining events in the event loop are processed when the Lambda function is next invoked, if AWS Lambda chooses to use the frozen process. */
     context.callbackWaitsForEmptyEventLoop = false;
@@ -61,6 +62,10 @@ exports.handler = async (event, context) => {
     const response = {
         statusCode: 200,
         body: JSON.stringify(users),
+        headers: {
+            'Content-Type': 'application/json',
+            'Access-Control-Allow-Origin': '*'
+        }
     };
 
     await closeConnection();

--- a/db/retrieveUsers/index.js
+++ b/db/retrieveUsers/index.js
@@ -47,7 +47,6 @@ async function closeConnection() {
 
 exports.handler = async (event, context) => {
     const isTest = event.queryStringParameters?.test === "true";
-    console.log(event, context);
 
     /* By default, the callback waits until the runtime event loop is empty before freezing the process and returning the results to the caller. Setting this property to false requests that AWS Lambda freeze the process soon after the callback is invoked, even if there are events in the event loop. AWS Lambda will freeze the process, any state data, and the events in the event loop. Any remaining events in the event loop are processed when the Lambda function is next invoked, if AWS Lambda chooses to use the frozen process. */
     context.callbackWaitsForEmptyEventLoop = false;

--- a/db/updateElo/index.ts
+++ b/db/updateElo/index.ts
@@ -9,7 +9,7 @@ const GAME_COLLECTION = "games";
 const elo = new EloRank();
 
 // Replace the following with your Atlas connection string
-const MONGODB_URI = "secret";
+const MONGODB_URI = "%MONGO_SECRET%";
 
 let cachedClient: MongoClient | null = null;
 let cachedDb: Db | null = null;
@@ -236,7 +236,7 @@ export const handler: Handler = async (event, context) => {
     /* By default, the callback waits until the runtime event loop is empty before freezing the process and returning the results to the caller. Setting this property to false requests that AWS Lambda freeze the process soon after the callback is invoked, even if there are events in the event loop. AWS Lambda will freeze the process, any state data, and the events in the event loop. Any remaining events in the event loop are processed when the Lambda function is next invoked, if AWS Lambda chooses to use the frozen process. */
     context.callbackWaitsForEmptyEventLoop = false;
 
-    const games: ReadonlyArray<IUpdateBody> = event ?? "";
+    const games: ReadonlyArray<IUpdateBody> = JSON.parse(event.body) ?? "";
 
     const db = await connectToDatabase(isTest);
     let dbUsers = await db
@@ -268,6 +268,10 @@ export const handler: Handler = async (event, context) => {
     const response = {
         statusCode: 200,
         body: JSON.stringify(responseBody),
+        headers: {
+            'Content-Type': 'application/json',
+            'Access-Control-Allow-Origin': '*'
+        }
     };
 
     await closeConnection();

--- a/ui/src/services/apiService.ts
+++ b/ui/src/services/apiService.ts
@@ -34,7 +34,6 @@ export const useFetchUsers = () =>
                 requestParams
             )}`
         ).then((res) => res.json())
-         .then(res => JSON.parse(res.body))
     );
 
 export const useFetchGames = (id?: string) => {
@@ -52,7 +51,6 @@ export const useFetchGames = (id?: string) => {
                 params
             )}`
         ).then((res) => res.json())
-         .then(res => JSON.parse(res.body))
     );
 };
 
@@ -63,7 +61,6 @@ export const useFetchAllStats = () =>
                 requestParams
             )}`
         ).then((res) => res.json())
-         .then(res => JSON.parse(res.body))
     );
 
 export const useRegisterUser = (
@@ -91,8 +88,7 @@ export const useRegisterUser = (
                         elo: 1000,
                     }),
                 }
-            ).then((res) => res.json())
-             .then(res => JSON.parse(res.body)),
+            ).then((res) => res.json()),
         options
     );
 
@@ -110,7 +106,6 @@ export const useSubmitResult = (
 ) =>
     useMutation<IUpdateResponse, string, ReadonlyArray<IGameRequest>>(
         (games) => {
-            console.log(JSON.stringify(games));
             return fetch(
                 `https://t6jhp0e39a.execute-api.eu-west-1.amazonaws.com/default/elo/updateElo${paramsToString(
                     requestParams
@@ -124,7 +119,6 @@ export const useSubmitResult = (
                     body: JSON.stringify(games),
                 }
             ).then((res) => res.json())
-             .then(res => JSON.parse(res.body))
         },
         options
     );


### PR DESCRIPTION
Lambda API integration sends a slightly different payload as event context and for API responses, so this should fix the issues there. Added API integration to ensure that the test db flag can be used by the lambdas.

Additionally, adding build steps for lambdas in prepration for deployment